### PR TITLE
updated log formats to include client ip

### DIFF
--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -85,10 +85,10 @@ Include "<%= @mod_load_dir %>/*.conf"
 Include "<%= @ports_file %>"
 
 <% unless @log_formats.has_key?('combined') -%>
-LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
 <% end -%>
 <% unless @log_formats.has_key?('common') -%>
-LogFormat "%h %l %u %t \"%r\" %>s %b" common
+LogFormat "%a %l %u %t \"%r\" %>s %b" common
 <% end -%>
 <% unless @log_formats.has_key?('referer') -%>
 LogFormat "%{Referer}i -> %U" referer


### PR DESCRIPTION
This change will ensure that apache logs the correct client ip instead of the loadbalancer ip when the apache server is behind a load balancer